### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <img src="https://github.com/AugustRush/Stellar/blob/master/title.png">
 
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg)](https://github.com/Carthage/Carthage)
-![](https://img.shields.io/cocoapods/v/Stellar.svg?label=Current%20Release) [![Packagist](https://img.shields.io/packagist/l/doctrine/orm.svg?maxAge=2592000?style=flat-square)](https://github.com/AugustRush/Stellar/blob/master/LICENSE.md) [![codebeat badge](https://codebeat.co/badges/e91a2d21-b20c-4b2b-a782-e0e2ecd65063)](https://codebeat.co/projects/github-com-augustrush-stellar) [![Travis branch](https://img.shields.io/travis/rust-lang/rust/master.svg?maxAge=2592000?style=flat-square)]() [![Cocoapods badge](https://img.shields.io/cocoapods/p/Stellar.svg?maxAge=2592000?style=flat-square)]()
+![](https://img.shields.io/cocoapods/v/Stellar.svg?label=Current%20Release) [![Packagist](https://img.shields.io/packagist/l/doctrine/orm.svg?maxAge=2592000?style=flat-square)](https://github.com/AugustRush/Stellar/blob/master/LICENSE.md) [![codebeat badge](https://codebeat.co/badges/e91a2d21-b20c-4b2b-a782-e0e2ecd65063)](https://codebeat.co/projects/github-com-augustrush-stellar) [![Travis branch](https://img.shields.io/travis/rust-lang/rust/master.svg?maxAge=2592000?style=flat-square)]() [![CocoaPods badge](https://img.shields.io/cocoapods/p/Stellar.svg?maxAge=2592000?style=flat-square)]()
 
 A fantastic Physical animation library for swift(Not Just Spring !!!), it is base on UIDynamic and extension to it, friendly APIs make you use it or custom your own animation very easily!
 
 ## Support
 
 ### Integration
-#### Cocoapods(iOS 8+)
-* You can use [Cocoapods](https://cocoapods.org/) to install Stellar by adding it to your Podfile:
+#### CocoaPods(iOS 8+)
+* You can use [CocoaPods](https://cocoapods.org/) to install Stellar by adding it to your Podfile:
 
 ```
 platform :ios, '8.0'


### PR DESCRIPTION
This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
