### PR TITLE
Rename autoreverses to reverses (Support Swift 4)

### DIFF
--- a/Sources/BasicConfigurable.swift
+++ b/Sources/BasicConfigurable.swift
@@ -12,6 +12,6 @@ public protocol BasicConfigurable: BasicChainable {
     func duration(_ d: CFTimeInterval) -> Self
     func easing(_ type: TimingFunctionType) -> Self
     func delay(_ d: CFTimeInterval) -> Self
-    func autoreverses() -> Self
+    func reverses() -> Self
     func repeatCount(_ count: Int) -> Self
 }

--- a/Sources/CALayer+Stellar.swift
+++ b/Sources/CALayer+Stellar.swift
@@ -220,7 +220,7 @@ extension CALayer: BasicConfigurable, SnapConfigurable, AttachmentConfigurable, 
         return self
     }
     
-    public func autoreverses() -> Self {
+    public func reverses() -> Self {
         context.changeAutoreverses(true)
         return self
     }

--- a/Sources/UIView+Stellar.swift
+++ b/Sources/UIView+Stellar.swift
@@ -228,7 +228,7 @@ extension UIView: BasicConfigurable, SnapConfigurable, AttachmentConfigurable, G
         return self
     }
     
-    public func autoreverses() -> Self {
+    public func reverses() -> Self {
         context.changeAutoreverses(true)
         return self
     }

--- a/StellarDemo/StellarDemo/Example3ViewController.swift
+++ b/StellarDemo/StellarDemo/Example3ViewController.swift
@@ -19,15 +19,15 @@ class Example3ViewController: UIViewController {
         for (index,line) in leftLines.enumerated() {
             let delay = Double(index) * 0.2
             line.moveX(200).duration(2).delay(delay)
-                .then().moveX(-200).makeColor(UIColor.green).easing(.linear).repeatCount(100).autoreverses().duration(2).animate()
-            line.makeWidth(80).delay(delay).duration(1).autoreverses().easing(.linear).repeatCount(100).animate()
+                .then().moveX(-200).makeColor(UIColor.green).easing(.linear).repeatCount(100).reverses().duration(2).animate()
+            line.makeWidth(80).delay(delay).duration(1).reverses().easing(.linear).repeatCount(100).animate()
         }
         
         for (index,line) in rightLines.enumerated() {
             let delay = Double(index) * 0.2
             line.moveX(-200).duration(2).delay(delay)
-                .then().moveX(200).makeColor(UIColor.purple).easing(.linear).repeatCount(100).autoreverses().duration(2).animate()
-            line.makeWidth(80).delay(delay).duration(1).autoreverses().easing(.linear).repeatCount(100).animate()
+                .then().moveX(200).makeColor(UIColor.purple).easing(.linear).repeatCount(100).reverses().duration(2).animate()
+            line.makeWidth(80).delay(delay).duration(1).reverses().easing(.linear).repeatCount(100).animate()
         }
 
 

--- a/StellarDemo/StellarDemo/Example8ViewController.swift
+++ b/StellarDemo/StellarDemo/Example8ViewController.swift
@@ -17,13 +17,13 @@ class Example8ViewController: UIViewController {
         
         switch index {
         case 0:
-            animateView.moveX(200).duration(1.0).easing(.default).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.default).reverses().animate()
         case 1:
-            animateView.moveX(200).duration(1.0).easing(.easeIn).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.easeIn).reverses().animate()
         case 2:
-            animateView.moveX(200).duration(1.0).easing(.easeOut).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.easeOut).reverses().animate()
         case 3:
-            animateView.moveX(200).duration(1.0).easing(.easeInEaseOut).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.easeInEaseOut).reverses().animate()
         default:
             print("")
         }
@@ -35,13 +35,13 @@ class Example8ViewController: UIViewController {
         
         switch index {
         case 0:
-            animateView.moveX(200).duration(1.0).easing(.linear).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.linear).reverses().animate()
         case 1:
-            animateView.moveX(200).duration(1.0).easing(.swiftOut).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.swiftOut).reverses().animate()
         case 2:
-            animateView.moveX(200).duration(1.0).easing(.backEaseIn).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.backEaseIn).reverses().animate()
         case 3:
-            animateView.moveX(200).duration(1.0).easing(.backEaseOut).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.backEaseOut).reverses().animate()
         default:
             print("")
         }
@@ -53,13 +53,13 @@ class Example8ViewController: UIViewController {
         
         switch index {
         case 0:
-            animateView.moveX(200).duration(1.0).easing(.backEaseInOut).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.backEaseInOut).reverses().animate()
         case 1:
-            animateView.moveX(200).duration(1.0).easing(.bounceOut).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.bounceOut).reverses().animate()
         case 2:
-            animateView.moveX(200).duration(1.0).easing(.sine).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.sine).reverses().animate()
         case 3:
-            animateView.moveX(200).duration(1.0).easing(.circ).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.circ).reverses().animate()
         default:
             print("")
         }
@@ -72,13 +72,13 @@ class Example8ViewController: UIViewController {
         
         switch index {
         case 0:
-            animateView.moveX(200).duration(1.0).easing(.exponentialIn).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.exponentialIn).reverses().animate()
         case 1:
-            animateView.moveX(200).duration(1.0).easing(.exponentialOut).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.exponentialOut).reverses().animate()
         case 2:
-            animateView.moveX(200).duration(1.0).easing(.elasticIn).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.elasticIn).reverses().animate()
         case 3:
-            animateView.moveX(200).duration(1.0).easing(.elasticOut).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.elasticOut).reverses().animate()
         default:
             print("")
         }
@@ -91,7 +91,7 @@ class Example8ViewController: UIViewController {
         
         switch index {
         case 0:
-            animateView.moveX(200).duration(1.0).easing(.bounceReverse).autoreverses().animate()
+            animateView.moveX(200).duration(1.0).easing(.bounceReverse).reverses().animate()
         case 1:
             100.0.animate(to: 200, duration: 1.0, delay: 0.0, type: .swiftOut, autoreverses: false, repeatCount: 0, render: { (d) in
                 print("current value is \(d)")

--- a/StellarDemo/StellarDemo/MyPlayground.playground/Sources/Sources/BasicConfigurable.swift
+++ b/StellarDemo/StellarDemo/MyPlayground.playground/Sources/Sources/BasicConfigurable.swift
@@ -12,7 +12,7 @@ public protocol BasicConfigurable: BasicChainable {
     func duration(_ d: CFTimeInterval) -> BasicConfigurable
     func easing(_ type: TimingFunctionType) -> BasicConfigurable
     func delay(_ d: CFTimeInterval) -> BasicConfigurable
-    func autoreverses() -> BasicConfigurable
+    func reverses() -> BasicConfigurable
     func repeatCount(_ count: Int) -> BasicConfigurable
 }
 
@@ -21,6 +21,6 @@ public protocol BasicConfigurable1: BasicChainable1 {
     func duration(_ d: CFTimeInterval) -> BasicConfigurable1
     func easing(_ type: TimingFunctionType) -> BasicConfigurable1
     func delay(_ d: CFTimeInterval) -> BasicConfigurable1
-    func autoreverses() -> BasicConfigurable1
+    func reverses() -> BasicConfigurable1
     func repeatCount(_ count: Int) -> BasicConfigurable1
 }


### PR DESCRIPTION
Previous function name conflicted with something ObjC.

`Method 'autoreverses()' with Objective-C selector 'autoreverses' conflicts with getter for 'autoreverses' with the same Objective-C selector`